### PR TITLE
Let demons caddy items (and gems)

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -552,7 +552,8 @@
       "missingTarget": "Missing target in target processing",
       "missingToken": "Missing token",
       "missingReactionTag": "Missing reaction tag",
-      "invalidReasonKey": "Invalid Reason key"
+      "invalidReasonKey": "Invalid Reason key",
+      "cantUseItems": "Demons can't use items!"
     }
   },
   "TYPES": {

--- a/src/module/data-models/actor/abstract/base.ts
+++ b/src/module/data-models/actor/abstract/base.ts
@@ -8,8 +8,7 @@ interface ReasonEndorsement {
   value: number;
 }
 
-export default abstract class SmtBaseActorData extends foundry.abstract
-  .TypeDataModel {
+export default abstract class SmtBaseActorData extends foundry.abstract.TypeDataModel {
   abstract override readonly type: CharacterClass;
 
   get actor() {
@@ -70,6 +69,10 @@ export default abstract class SmtBaseActorData extends foundry.abstract
     );
 
     return data.lv - data.baseLv - statPoints + data.incenseUsed;
+  }
+
+  get canUseItems() {
+    return this.type !== "demon";
   }
 
   static override migrateData(source: Record<string, unknown>) {

--- a/src/module/documents/actor/actor-sheet.ts
+++ b/src/module/documents/actor/actor-sheet.ts
@@ -388,6 +388,12 @@ export default class SmtActorSheet extends ActorSheet<SmtActor> {
       throw new Error(msg);
     }
 
+    if (item.type === "inventoryItem" && !this.actor.system.canUseItems) {
+      const msg = game.i18n.localize("SMT.error.cantUseItems");
+      ui.notifications.notify(msg);
+      return;
+    }
+
     const targets =
       game.user.targets.size > 0
         ? ([...game.user.targets.values()] as SmtToken[]).map((token) => ({

--- a/src/templates/actor/actor-sheet.hbs
+++ b/src/templates/actor/actor-sheet.hbs
@@ -6,9 +6,7 @@
   <nav class="sheet-tabs tabs" data-group="primary">
     {{!-- Default tab is defined in actor-sheet.ts --}}
     <a class="item resource-label" data-tab="main">{{localize "SMT.tabs.main"}}</a>
-    {{#if (ne actor.type "demon")}}
     <a class="item resource-label" data-tab="inventory">{{localize "SMT.tabs.inventory"}}</a>
-    {{/if}}
     <a class="item resource-label" data-tab="bio">{{localize "SMT.tabs.bio"}}</a>
     <a class="item resource-label" data-tab="effects">{{localize "SMT.tabs.effects"}}</a>
   </nav>
@@ -21,11 +19,9 @@
     </div>
 
     {{!-- Inventory Tab --}}
-    {{#if (ne actor.type "demon")}}
     <div class="tab inventory" data-group="primary" data-tab="inventory">
       {{> "systems/smt-tc/templates/parts/actor/tabs/inventory.hbs"}}
     </div>
-    {{/if}}
 
     {{!-- Bio Tab --}}
     <div class="tab bio" data-group="primary" data-tab="bio">


### PR DESCRIPTION
The inventory tab now appears for demons and displays their items and gems. Trying to use a consumable fails and emits a notification if you're a demon.

Closes #2, closes #4