### PR TITLE
Fix element boosts ignoring potency

### DIFF
--- a/src/module/helpers/dice.ts
+++ b/src/module/helpers/dice.ts
@@ -418,7 +418,7 @@ export default class SmtDice {
 
       const { power, critPower, powerRoll } = attackData.hasPowerRoll
         ? await this.powerRoll({
-            basePower: Math.floor(attackData.basePower),
+            basePower: attackData.basePower,
             potency: attackData.potency,
             potencyMod,
             powerBoost: attackData.powerBoost,


### PR DESCRIPTION
Element boosts now correctly account for the potency of skills in addition to the character's base power.

Closes #12