### PR TITLE
Make ctrl skip skill costs

### DIFF
--- a/src/module/documents/actor/actor-sheet.ts
+++ b/src/module/documents/actor/actor-sheet.ts
@@ -413,6 +413,8 @@ export default class SmtActorSheet extends ActorSheet<SmtActor> {
     // Is the user signaling to show the dialog?
     const dialogKey =
       event.shiftKey != game.settings.get("smt-tc", "showRollDialogByDefault");
+    
+    const skipCost = event.ctrlKey;
 
     // Show the dialog anyway if it's a consumable item
     const showDialog = consumeOnUse || dialogKey;
@@ -436,6 +438,7 @@ export default class SmtActorSheet extends ActorSheet<SmtActor> {
       targets,
       tnMod,
       potencyMod,
+      skipCost,
     });
   }
 

--- a/src/module/helpers/dice.ts
+++ b/src/module/helpers/dice.ts
@@ -57,6 +57,7 @@ interface ItemRollData {
   targets?: TargetData[];
   tnMod?: number;
   potencyMod?: number;
+  skipCost?: boolean;
 }
 
 interface TargetProcessData {
@@ -186,7 +187,7 @@ export default class SmtDice {
     return {
       inflict,
       roll,
-    }
+    };
   }
 
   // TODO: Call this directly instead of using sheetRoll
@@ -302,6 +303,7 @@ export default class SmtDice {
     targets,
     tnMod = 0,
     potencyMod = 0,
+    skipCost = false,
   }: ItemRollData = {}) {
     const actor = item?.parent;
 
@@ -319,7 +321,7 @@ export default class SmtDice {
 
     const rolls: Roll[] = [];
 
-    const costPaid = await item.payCost();
+    const costPaid = skipCost ? true : await item.payCost();
 
     // If it's not an attack item, we don't roll an attack
     const auto = attackData?.auto ?? true;


### PR DESCRIPTION
Holding the ctrl key when rolling a skill now skips paying its cost. This doesn't fully resolve the problem in #8, but does provide a reasonably quick workaround for one of the most common use cases.